### PR TITLE
corecties in 1.0.4

### DIFF
--- a/1.0.4/opdracht/GIO01.xml
+++ b/1.0.4/opdracht/GIO01.xml
@@ -4,7 +4,7 @@
     xmlns:data="https://standaarden.overheid.nl/stop/imop/data/"
     xmlns:lvbb="http://standaarden.overheid.nl/lvbb/stop/"
     xmlns:xlink="http://www.w3.org/1999/xlink"
-    xmlns:uit="https://standaarden.overheid.nl/lvbb/DSO-PI12" schemaversie="0.98.4"
+    xmlns:uit="https://standaarden.overheid.nl/lvbb/DSO-PI12" schemaversie="1.0.4"
     xmlns:gml="http://www.opengis.net/gml/3.2">
     <InformatieObjectVersie>
         <ExpressionIdentificatie xmlns="https://standaarden.overheid.nl/stop/imop/data/">

--- a/1.0.4/opdracht/GIO02.xml
+++ b/1.0.4/opdracht/GIO02.xml
@@ -4,7 +4,7 @@
    xmlns:data="https://standaarden.overheid.nl/stop/imop/data/"
    xmlns:lvbb="http://standaarden.overheid.nl/lvbb/stop/"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:uit="https://standaarden.overheid.nl/lvbb/DSO-PI12" schemaversie="0.98.4"
+   xmlns:uit="https://standaarden.overheid.nl/lvbb/DSO-PI12" schemaversie="1.0.4"
    xmlns:gml="http://www.opengis.net/gml/3.2">
    <InformatieObjectVersie>
       <ExpressionIdentificatie xmlns="https://standaarden.overheid.nl/stop/imop/data/">

--- a/1.0.4/opdracht/Locatie01.gml
+++ b/1.0.4/opdracht/Locatie01.gml
@@ -8,8 +8,8 @@
                                      schemaversie="1.0.4">
    <geo:context>
       <gio:GeografischeContext>
-         <gio:achtergrondVerwijzing/>
-         <gio:achtergrondActualiteit/>
+      	<gio:achtergrondVerwijzing>top10nl</gio:achtergrondVerwijzing>
+      	<gio:achtergrondActualiteit>2019-01-01</gio:achtergrondActualiteit>
       </gio:GeografischeContext>
    </geo:context>
    <geo:vastgesteldeVersie>

--- a/1.0.4/opdracht/Locatie02.gml
+++ b/1.0.4/opdracht/Locatie02.gml
@@ -8,8 +8,8 @@
                                      schemaversie="1.0.4">
    <geo:context>
       <gio:GeografischeContext>
-         <gio:achtergrondVerwijzing/>
-         <gio:achtergrondActualiteit/>
+      	<gio:achtergrondVerwijzing>top10nl</gio:achtergrondVerwijzing>
+      	<gio:achtergrondActualiteit>2019-01-01</gio:achtergrondActualiteit>
       </gio:GeografischeContext>
    </geo:context>
    <geo:vastgesteldeVersie>

--- a/1.0.4/opdracht/manifest-ow.xml
+++ b/1.0.4/opdracht/manifest-ow.xml
@@ -9,7 +9,7 @@
       <Bestand>
          <naam>owTekstdeel.xml</naam>
          <objecttype>Tekstdeel</objecttype>
-         <objecttype>FormeleDivisie</objecttype>
+         <objecttype>Divisie</objecttype>
          <objecttype>Hoofdlijn</objecttype>
       </Bestand>
       <Bestand>

--- a/1.0.4/opdracht/manifest.xml
+++ b/1.0.4/opdracht/manifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<manifest xmlns="http://www.overheid.nl/2017/lvbb"
-    schemaversie="0.98.4">
+<manifest xmlns="http://www.overheid.nl/2017/lvbb">
     <bestand>
         <bestandsnaam>GIO01.xml</bestandsnaam>
         <contentType>application/xml</contentType>
@@ -26,7 +25,7 @@
         <contentType>application/xml</contentType>
     </bestand>
     <bestand>
-        <bestandsnaam>opProjectbesluit.xml</bestandsnaam>
+        <bestandsnaam>opProjectBesluit.xml</bestandsnaam>
         <contentType>application/xml</contentType>
     </bestand>
     <bestand>

--- a/1.0.4/opdracht/opdracht.xml
+++ b/1.0.4/opdracht/opdracht.xml
@@ -3,6 +3,6 @@
    <lvbb:idLevering>Projectbesluit_Zuidasdok</lvbb:idLevering>
    <lvbb:idBevoegdGezag>00000001001003124000</lvbb:idBevoegdGezag>
    <lvbb:idAanleveraar>00000001001003124000</lvbb:idAanleveraar>
-   <lvbb:publicatie>opProjectbesluit.xml</lvbb:publicatie>
+   <lvbb:publicatie>opProjectBesluit.xml</lvbb:publicatie>
    <lvbb:datumBekendmaking>2019-03-08</lvbb:datumBekendmaking>
 </lvbb:publicatieOpdracht>

--- a/1.0.4/opdracht/owTekstdeel.xml
+++ b/1.0.4/opdracht/owTekstdeel.xml
@@ -1,137 +1,129 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ow-dc:owBestand xmlns:ow-dc="http://www.geostandaarden.nl/imow/bestanden/deelbestand"
-                 xmlns:ow="http://www.geostandaarden.nl/imow/owobject"
-                 xmlns:da="http://www.geostandaarden.nl/imow/datatypenalgemeen"
-                 xmlns:sl="http://www.geostandaarden.nl/bestanden-ow/standlevering-generiek"
-                 xmlns:ga="http://www.geostandaarden.nl/imow/gebiedsaanwijzing"
-                 xmlns:k="http://www.geostandaarden.nl/imow/kaart"
-                 xmlns:l="http://www.geostandaarden.nl/imow/locatie"
-                 xmlns:p="http://www.geostandaarden.nl/imow/pons"
-                 xmlns:r="http://www.geostandaarden.nl/imow/regels"
-                 xmlns:rol="http://www.geostandaarden.nl/imow/regelsoplocatie"
-                 xmlns:vt="http://www.geostandaarden.nl/imow/vrijetekst"
-                 xmlns:xlink="http://www.w3.org/1999/xlink"
-                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://www.geostandaarden.nl/imow/bestanden/deelbestand https://register.geostandaarden.nl/xmlschema/tpod/v1.0.3/bestanden-ow/deelbestand-ow/IMOW_Deelbestand.xsd">
-   <sl:standBestand>
-      <sl:dataset>Zuidasdok</sl:dataset>
-      <sl:inhoud>
-         <sl:gebied>Amsterdam Zuid</sl:gebied>
-         <sl:leveringsId>projectbesluit-zuidasdok</sl:leveringsId>
-         <sl:objectTypen>
-            <sl:objectType>Tekstdeel</sl:objectType>
-            <sl:objectType>Divisie</sl:objectType>
-            <sl:objectType>Hoofdlijn</sl:objectType>
-         </sl:objectTypen>
-      </sl:inhoud>
-      <!-- Vrije tekst Inleiding, Tracébesluit en bestemmingsplan-->
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Divisie wId="pv27_1__fdvs_o_1__fdvs_o_1__fdvs_o_2">
-               <vt:identificatie>nl.imow-pv27.divisie.2019000001</vt:identificatie>
-            </vt:Divisie>
-         </ow-dc:owObject>
-      </sl:stand>
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Tekstdeel>
-               <vt:identificatie>nl.imow-pv27.tekstdeel.2019000001</vt:identificatie>
-               <vt:idealisatie>http://standaarden.omgevingswet.overheid.nl/idealisatie/id/concept/Exact</vt:idealisatie>
-               <vt:thema>http://standaarden.omgevingswet.overheid.nl/milieualgemeenenoverigemilieuaspecten/id/concept/MilieuAlgemeenEnOverigeMilieuaspectenAlgemeen</vt:thema>
-               <vt:divisieaanduiding>
-                  <vt:DivisieRef xlink:href="nl.imow-pv27.divisie.2019000001"/>
-               </vt:divisieaanduiding>
-               <vt:locatieaanduiding>
-                  <l:LocatieRef xlink:href="nl.imow-pv27.gebied.2019000001"/>
-               </vt:locatieaanduiding>
-            </vt:Tekstdeel>
-         </ow-dc:owObject>
-      </sl:stand>
-      <!-- Hoofdstuk 2 -->
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Hoofdlijn>
-               <vt:identificatie>nl.imow-pv27.hoofdlijn.2019000001</vt:identificatie>
-               <vt:soort>Maatregel</vt:soort>
-               <vt:naam>Geluid</vt:naam>
-            </vt:Hoofdlijn>
-         </ow-dc:owObject>
-      </sl:stand>
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Divisie wId="pv27_1__fdvs_o_1__fdvs_o_3">
-               <vt:identificatie>nl.imow-pv27.divisie.2019000002</vt:identificatie>
-            </vt:Divisie>
-         </ow-dc:owObject>
-      </sl:stand>
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Tekstdeel>
-               <vt:identificatie>nl.imow-pv27.tekstdeel.2019000002</vt:identificatie>
-               <vt:idealisatie>http://standaarden.omgevingswet.overheid.nl/idealisatie/id/concept/Exact</vt:idealisatie>
-               <vt:divisieaanduiding>
-                  <vt:DivisieRef xlink:href="nl.imow-pv27.divisie.2019000002"/>
-               </vt:divisieaanduiding>
-               <vt:hoofdlijnaanduiding>
-                  <vt:HoofdlijnRef xlink:href="nl.imow-pv27.hoofdlijn.2019000001"/>
-               </vt:hoofdlijnaanduiding>
-            </vt:Tekstdeel>
-         </ow-dc:owObject>
-      </sl:stand>
-      <!-- Hoofdstuk 3 -->
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Hoofdlijn>
-               <vt:identificatie>nl.imow-pv27.hoofdlijn.2019000002</vt:identificatie>
-               <vt:soort>Maatregel</vt:soort>
-               <vt:naam>Verkeer</vt:naam>
-            </vt:Hoofdlijn>
-         </ow-dc:owObject>
-      </sl:stand>
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Divisie wId="pv27_1__fdvs_o_1__fdvs_o_4">
-               <vt:identificatie>nl.imow-pv27.divisie.2019000003</vt:identificatie>
-            </vt:Divisie>
-         </ow-dc:owObject>
-      </sl:stand>
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Tekstdeel>
-               <vt:identificatie>nl.imow-pv27.tekstdeel.2019000003</vt:identificatie>
-               <vt:idealisatie>http://standaarden.omgevingswet.overheid.nl/idealisatie/id/concept/Exact</vt:idealisatie>
-               <vt:divisieaanduiding>
-                  <vt:DivisieRef xlink:href="nl.imow-pv27.divisie.2019000003"/>
-               </vt:divisieaanduiding>
-               <vt:hoofdlijnaanduiding>
-                  <vt:HoofdlijnRef xlink:href="nl.imow-pv27.hoofdlijn.2019000002"/>
-               </vt:hoofdlijnaanduiding>
-            </vt:Tekstdeel>
-         </ow-dc:owObject>
-      </sl:stand>
-      <!-- Hoofdstuk 9 -->
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Divisie wId="pv27_1__fdvs_o_1__fdvs_o_6">
-               <vt:identificatie>nl.imow-pv27.divisie.2019000004</vt:identificatie>
-            </vt:Divisie>
-         </ow-dc:owObject>
-      </sl:stand>
-      <sl:stand>
-         <ow-dc:owObject>
-            <vt:Tekstdeel>
-               <vt:identificatie>nl.imow-pv27.tekstdeel.2019000004</vt:identificatie>
-               <vt:idealisatie>http://standaarden.omgevingswet.overheid.nl/idealisatie/id/concept/Exact</vt:idealisatie>
-               <!--Let op: waarde "Verkeer" ontbreekt in waardelijst "Thema"-->
-               <vt:thema>http://standaarden.omgevingswet.overheid.nl/onbekend</vt:thema>
-               <vt:divisieaanduiding>
-                  <vt:DivisieRef xlink:href="nl.imow-pv27.divisie.2019000004"/>
-               </vt:divisieaanduiding>
-               <vt:gebiedsaanwijzing>
-                  <ga:GebiedsaanwijzingRef xlink:href="nl.imow-pv27.gebiedsaanwijzing.2019000001"/>
-               </vt:gebiedsaanwijzing>
-            </vt:Tekstdeel>
-         </ow-dc:owObject>
-      </sl:stand>
-   </sl:standBestand>
+<ow-dc:owBestand xmlns:ow-dc="http://www.geostandaarden.nl/imow/bestanden/deelbestand" xmlns:ow="http://www.geostandaarden.nl/imow/owobject"
+	xmlns:da="http://www.geostandaarden.nl/imow/datatypenalgemeen" xmlns:sl="http://www.geostandaarden.nl/bestanden-ow/standlevering-generiek"
+	xmlns:ga="http://www.geostandaarden.nl/imow/gebiedsaanwijzing" xmlns:k="http://www.geostandaarden.nl/imow/kaart" xmlns:l="http://www.geostandaarden.nl/imow/locatie"
+	xmlns:p="http://www.geostandaarden.nl/imow/pons" xmlns:r="http://www.geostandaarden.nl/imow/regels" xmlns:rol="http://www.geostandaarden.nl/imow/regelsoplocatie"
+	xmlns:vt="http://www.geostandaarden.nl/imow/vrijetekst" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.geostandaarden.nl/imow/bestanden/deelbestand https://register.geostandaarden.nl/xmlschema/tpod/v1.0.3/bestanden-ow/deelbestand-ow/IMOW_Deelbestand.xsd">
+	<sl:standBestand>
+		<sl:dataset>Zuidasdok</sl:dataset>
+		<sl:inhoud>
+			<sl:gebied>Amsterdam Zuid</sl:gebied>
+			<sl:leveringsId>projectbesluit-zuidasdok</sl:leveringsId>
+			<sl:objectTypen>
+				<sl:objectType>Tekstdeel</sl:objectType>
+				<sl:objectType>Divisie</sl:objectType>
+				<sl:objectType>Hoofdlijn</sl:objectType>
+			</sl:objectTypen>
+		</sl:inhoud>
+		<!-- Vrije tekst Inleiding, Tracébesluit en bestemmingsplan-->
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Divisie wId="pv27_1__fdvs_o_1__fdvs_o_1__fdvs_o_2">
+					<vt:identificatie>nl.imow-pv27.divisie.2019000001</vt:identificatie>
+				</vt:Divisie>
+			</ow-dc:owObject>
+		</sl:stand>
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Tekstdeel>
+					<vt:identificatie>nl.imow-pv27.tekstdeel.2019000001</vt:identificatie>
+					<vt:idealisatie>http://standaarden.omgevingswet.overheid.nl/idealisatie/id/concept/Exact</vt:idealisatie>
+					<vt:thema>http://standaarden.omgevingswet.overheid.nl/milieualgemeenenoverigemilieuaspecten/id/concept/MilieuAlgemeenEnOverigeMilieuaspectenAlgemeen</vt:thema>
+					<vt:divisieaanduiding>
+						<vt:DivisieRef xlink:href="nl.imow-pv27.divisie.2019000001"/>
+					</vt:divisieaanduiding>
+					<vt:locatieaanduiding>
+						<l:LocatieRef xlink:href="nl.imow-pv27.gebied.2019000001"/>
+					</vt:locatieaanduiding>
+				</vt:Tekstdeel>
+			</ow-dc:owObject>
+		</sl:stand>
+		<!-- Hoofdstuk 2 -->
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Hoofdlijn>
+					<vt:identificatie>nl.imow-pv27.hoofdlijn.2019000001</vt:identificatie>
+					<vt:soort>Maatregel</vt:soort>
+					<vt:naam>Geluid</vt:naam>
+				</vt:Hoofdlijn>
+			</ow-dc:owObject>
+		</sl:stand>
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Divisie wId="pv27_1__fdvs_o_1__fdvs_o_3">
+					<vt:identificatie>nl.imow-pv27.divisie.2019000002</vt:identificatie>
+				</vt:Divisie>
+			</ow-dc:owObject>
+		</sl:stand>
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Tekstdeel>
+					<vt:identificatie>nl.imow-pv27.tekstdeel.2019000002</vt:identificatie>
+					<vt:idealisatie>http://standaarden.omgevingswet.overheid.nl/idealisatie/id/concept/Exact</vt:idealisatie>
+					<vt:divisieaanduiding>
+						<vt:DivisieRef xlink:href="nl.imow-pv27.divisie.2019000002"/>
+					</vt:divisieaanduiding>
+					<vt:hoofdlijnaanduiding>
+						<vt:HoofdlijnRef xlink:href="nl.imow-pv27.hoofdlijn.2019000001"/>
+					</vt:hoofdlijnaanduiding>
+				</vt:Tekstdeel>
+			</ow-dc:owObject>
+		</sl:stand>
+		<!-- Hoofdstuk 3 -->
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Hoofdlijn>
+					<vt:identificatie>nl.imow-pv27.hoofdlijn.2019000002</vt:identificatie>
+					<vt:soort>Maatregel</vt:soort>
+					<vt:naam>Verkeer</vt:naam>
+				</vt:Hoofdlijn>
+			</ow-dc:owObject>
+		</sl:stand>
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Divisie wId="pv27_1__fdvs_o_1__fdvs_o_4">
+					<vt:identificatie>nl.imow-pv27.divisie.2019000003</vt:identificatie>
+				</vt:Divisie>
+			</ow-dc:owObject>
+		</sl:stand>
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Tekstdeel>
+					<vt:identificatie>nl.imow-pv27.tekstdeel.2019000003</vt:identificatie>
+					<vt:idealisatie>http://standaarden.omgevingswet.overheid.nl/idealisatie/id/concept/Exact</vt:idealisatie>
+					<vt:divisieaanduiding>
+						<vt:DivisieRef xlink:href="nl.imow-pv27.divisie.2019000003"/>
+					</vt:divisieaanduiding>
+					<vt:hoofdlijnaanduiding>
+						<vt:HoofdlijnRef xlink:href="nl.imow-pv27.hoofdlijn.2019000002"/>
+					</vt:hoofdlijnaanduiding>
+				</vt:Tekstdeel>
+			</ow-dc:owObject>
+		</sl:stand>
+		<!-- Hoofdstuk 9 -->
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Divisie wId="pv27_1__fdvs_o_1__fdvs_o_6">
+					<vt:identificatie>nl.imow-pv27.divisie.2019000004</vt:identificatie>
+				</vt:Divisie>
+			</ow-dc:owObject>
+		</sl:stand>
+		<sl:stand>
+			<ow-dc:owObject>
+				<vt:Tekstdeel>
+					<vt:identificatie>nl.imow-pv27.tekstdeel.2019000004</vt:identificatie>
+					<vt:idealisatie>http://standaarden.omgevingswet.overheid.nl/idealisatie/id/concept/Exact</vt:idealisatie>
+					<!--Let op: waarde "Verkeer" ontbreekt in waardelijst "Thema"-->
+					<vt:thema>http://standaarden.omgevingswet.overheid.nl/id/conceptscheme/Infrastructuur</vt:thema>
+					<vt:divisieaanduiding>
+						<vt:DivisieRef xlink:href="nl.imow-pv27.divisie.2019000004"/>
+					</vt:divisieaanduiding>
+					<vt:gebiedsaanwijzing>
+						<ga:GebiedsaanwijzingRef xlink:href="nl.imow-pv27.gebiedsaanwijzing.2019000001"/>
+					</vt:gebiedsaanwijzing>
+				</vt:Tekstdeel>
+			</ow-dc:owObject>
+		</sl:stand>
+	</sl:standBestand>
 </ow-dc:owBestand>


### PR DESCRIPTION
schemaversie manifest.xml verwijderd
schemaversie GIO's moet aangepast (2x)
'opProjectbesluit.xml' in manifest.xml/opdracht.xml > 'opProjectBesluit.xml'
'Locatie01/2.gml'
         <geo:FRBRWork/>
         <geo:FRBRExpression/>
ingevuld.

manifest-ow.xml: FormeleDivisie > Divisie
'nl.imow-pv27.tekstdeel.2019000004' van  http://standaarden.omgevingswet.overheid.nl/onbekend' naar  http://standaarden.omgevingswet.overheid.nl/id/conceptscheme/Infrastructuur